### PR TITLE
Use ASM provided by core

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,29 @@
             <groupId>com.github.jnr</groupId>
             <artifactId>jnr-posix</artifactId>
             <version>3.1.7</version>
+            <exclusions>
+                <!-- Provided by Jenkins core -->
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-analysis</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-commons</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-tree</artifactId>
+                </exclusion>
+                <exclusion>
+                    <groupId>org.ow2.asm</groupId>
+                    <artifactId>asm-util</artifactId>
+                </exclusion>
+            </exclusions>
         </dependency>
     </dependencies>
 
@@ -67,7 +90,7 @@
                 <groupId>org.jenkins-ci.tools</groupId>
                 <artifactId>maven-hpi-plugin</artifactId>
                 <configuration>
-                    <maskClasses>com.kenai.jffi. com.kenai.jnr. hudson.os.PosixAPI jni. jnr. org.objectweb.asm.</maskClasses>
+                    <maskClasses>com.kenai.jffi. com.kenai.jnr. hudson.os.PosixAPI jni. jnr.</maskClasses>
                 </configuration>
             </plugin>
         </plugins>


### PR DESCRIPTION
Alternative to #26. I think I'll consume ASM from core until I have the time to properly separate it out into a dedicated ASM API plugin.