### PR TITLE
Remove usages of `PosixException`

### DIFF
--- a/src/main/java/hudson/os/PosixAPI.java
+++ b/src/main/java/hudson/os/PosixAPI.java
@@ -1,7 +1,6 @@
 package hudson.os;
 
 import jenkins.util.SystemProperties;
-import jnr.constants.platform.Errno;
 import jnr.posix.POSIX;
 import jnr.posix.POSIXFactory;
 import jnr.posix.util.DefaultPOSIXHandler;

--- a/src/main/java/hudson/os/PosixAPI.java
+++ b/src/main/java/hudson/os/PosixAPI.java
@@ -18,7 +18,7 @@ public class PosixAPI {
 
     /**
      * Load the JNR implementation of the POSIX APIs for the current platform. Runtime exceptions
-     * will be of type {@link PosixException}. {@link IllegalStateException} will be thrown for
+     * will be of type {@link RuntimeException}. {@link IllegalStateException} will be thrown for
      * methods not implemented on this platform.
      *
      * @return some implementation (even on Windows or unsupported Unix)
@@ -26,16 +26,6 @@ public class PosixAPI {
     public static synchronized POSIX jnr() {
         if (posix == null) {
             posix = POSIXFactory.getPOSIX(new DefaultPOSIXHandler() {
-                @Override
-                public void error(Errno error, String extraData) {
-                    throw new PosixException("native error " + error.description() + " " + extraData);
-                }
-
-                @Override
-                public void error(Errno error, String methodName, String extraData) {
-                    throw new PosixException("native error calling " + methodName + ": " + error.description() + " " + extraData);
-                }
-
                 @Override
                 public boolean isVerbose() {
                     return VERBOSE;


### PR DESCRIPTION
Adapting to jenkinsci/jenkins#6345. See also https://github.com/jnr/jnr-posix/blob/a2100e3961e5996f3092e090f30d6bc7b0424312/src/main/java/jnr/posix/util/DefaultPOSIXHandler.java#L19-L25